### PR TITLE
chore(deps-dev): bump @eslint/js to 9.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.32.0",
+        "@eslint/js": "^9.34.0",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^24.3.0",
         "eslint": "^9.34.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.32.0",
+    "@eslint/js": "^9.34.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^24.3.0",
     "eslint": "^9.34.0",


### PR DESCRIPTION
Dependabot の #91 が閉じられていたため、手動で @eslint/js を 9.34.0 に更新しました。\n- lint/build 通過済み\n- スカッシュマージ予定